### PR TITLE
[WIP] Add error handling to database access in `add`

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -32,7 +32,11 @@ var addCmd = &cobra.Command{
 	Short: "Creates a new task.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
-			data.OpenDatabase()
+			err := data.OpenDatabase()
+			if err != nil {
+				log.Fatal(err)
+			}
+
 			data.MigrateDatabase()
 			createNewTaskFromArgs(args)
 		} else {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,7 +27,10 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all tasks.",
 	Run: func(cmd *cobra.Command, args []string) {
-		data.OpenDatabase()
+		err := data.OpenDatabase()
+		if err != nil {
+			log.Fatal(err)
+		}
 		data.MigrateDatabase()
 
 		ListTasks()


### PR DESCRIPTION
## description

Add error handling to the call to `data.OpenDatabase()` in `cmd/add.go`.