### PR TITLE
[WIP] Add steps feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.db
+.termdbms/

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -17,6 +17,12 @@ func createNewTaskFromArgs(args []string) {
 	data.InsertTask(label)
 }
 
+func createNewTaskFromArgsAndSteps(args []string) {
+	label := strings.Join(args, " ")
+	log.Printf("Inserting task [%s] with %d steps!\n", label, len(steps))
+	data.InsertTaskWithSteps(label, steps)
+}
+
 func declareFlagsForAdd() {
 	// general.list_after_add
 	addCmd.Flags().BoolP(

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,6 +9,8 @@ import (
 	"github.com/vlbeaudoin/tasklist/data"
 )
 
+var steps []string
+
 func createNewTaskFromArgs(args []string) {
 	label := strings.Join(args, " ")
 	log.Printf("Inserting task [%s]!\n", label)
@@ -23,6 +25,11 @@ func declareFlagsForAdd() {
 	viper.BindPFlag(
 		"general.list_after_add",
 		addCmd.Flags().Lookup("list-after-add"))
+
+	// steps
+	addCmd.Flags().StringSliceVarP(
+		&steps, "steps", "s", nil,
+		"Task steps")
 }
 
 // addCmd represents the add command

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -46,7 +46,21 @@ var addCmd = &cobra.Command{
 		if len(args) > 0 {
 			data.OpenDatabase()
 			data.MigrateDatabase()
-			createNewTaskFromArgs(args)
+
+			if len(steps) > 0 {
+				// Show steps before insertion
+				log.Println("Steps:")
+				for _, step := range steps {
+					log.Println("-", step)
+				}
+
+				// Insert task with steps
+				createNewTaskFromArgsAndSteps(args)
+			} else {
+				// Insert task without steps
+				createNewTaskFromArgs(args)
+			}
+
 		} else {
 			log.Fatal("Not enough arguments after `add`.")
 		}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/vlbeaudoin/tasklist/data"
+)
+
+func stringsToTaskIDs(strings []string) (taskIDs []uint64) {
+	for _, s := range strings {
+		if taskID, err := strconv.ParseUint(s, 10, 0); err != nil {
+			log.Println(err)
+		} else {
+			// inspectTaskByID(taskID)
+			taskIDs = append(taskIDs, taskID)
+		}
+	}
+	return taskIDs
+}
+
+func inspectTaskByID(taskID uint64) error {
+	// Task
+	task, err := data.FindTaskByID(taskID)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[%d] %s", task.ID, task.Label)
+
+	// Steps
+	steps, err := data.FindStepsByTaskID(taskID)
+	if err != nil {
+		return err
+	}
+
+	for _, step := range steps {
+		completed := ' '
+		if step.Completed {
+			completed = 'x'
+		}
+		log.Printf("- [%c] %s", completed, step.Description)
+	}
+
+	return nil
+}
+
+// inspectCmd represents the inspect command
+var inspectCmd = &cobra.Command{
+	Use:   "inspect",
+	Short: "Inspects a task and its steps.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			log.Fatal("Inspect requires at least one task ID.")
+		}
+		data.OpenDatabase()
+		data.MigrateDatabase()
+
+		for _, taskID := range stringsToTaskIDs(args) {
+			err := inspectTaskByID(taskID)
+			if err != nil {
+				log.Println(err)
+			}
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(inspectCmd)
+}

--- a/data/data.go
+++ b/data/data.go
@@ -14,6 +14,14 @@ var db *gorm.DB
 type Task struct {
 	gorm.Model
 	Label string `csv:"label" json:"label"`
+	Steps []Step
+}
+
+type Step struct {
+	gorm.Model
+	Description string `csv:"description" json:"description"`
+	Completed   bool   `csv:"completed" json:"completed"`
+	TaskID      uint   `csv:"taskid" json:"taskid"`
 }
 
 func OpenDatabase() error {
@@ -52,13 +60,32 @@ func OpenDatabase() error {
 }
 
 func MigrateDatabase() {
-	db.AutoMigrate(&Task{})
+	db.AutoMigrate(&Task{}, &Step{})
 }
 
 func InsertTask(label string) {
 	db.Create(&Task{
 		Label: label,
 	})
+}
+
+func InsertTaskWithSteps(label string, steps []string) {
+	if len(steps) > 0 {
+		// Populate steps
+		structSteps := []Step{}
+
+		for _, step := range steps {
+			structSteps = append(structSteps, Step{Description: step})
+		}
+
+		// Insert task and steps
+		db.Create(&Task{
+			Label: label,
+			Steps: structSteps,
+		})
+	} else {
+		InsertTask(label)
+	}
 }
 
 func ListTasks() ([]Task, error) {

--- a/data/data.go
+++ b/data/data.go
@@ -61,8 +61,9 @@ func OpenDatabase() error {
 	return sqlDB.Ping()
 }
 
-func MigrateDatabase() {
-	db.AutoMigrate(&Task{}, &Step{})
+func MigrateDatabase() error {
+	err := db.AutoMigrate(&Task{}, &Step{})
+	return err
 }
 
 func InsertTask(label string) {

--- a/data/data.go
+++ b/data/data.go
@@ -13,12 +13,14 @@ var db *gorm.DB
 
 type Task struct {
 	gorm.Model
+	ID    uint64 `mapper:"id" json:"id"`
 	Label string `csv:"label" json:"label"`
 	Steps []Step
 }
 
 type Step struct {
 	gorm.Model
+	ID          uint64 `mapper:"id" json:"id"`
 	Description string `csv:"description" json:"description"`
 	Completed   bool   `csv:"completed" json:"completed"`
 	TaskID      uint   `csv:"taskid" json:"taskid"`

--- a/data/data.go
+++ b/data/data.go
@@ -109,3 +109,13 @@ func InsertTasks(tasks []*Task) error {
 
 	return nil
 }
+
+func FindTaskByID(taskID uint64) (task Task, err error) {
+	result := db.First(&task, taskID)
+	return task, result.Error
+}
+
+func FindStepsByTaskID(taskID uint64) (steps []Step, err error) {
+	result := db.Where("task_id = ?", taskID).Find(&steps)
+	return steps, result.Error
+}


### PR DESCRIPTION
Steps can be added with the `--steps, -s` flag in the `addCmd`.

Steps are associated to a task through the foreign key `task_id`.

- [x] Add possibility to `import` tasks with steps.
  - [x] Add csv/json labels to `Steps []Step` definition in Task struct